### PR TITLE
feat(frontend): Add initial zustand stores

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.11.0"
+        "react-router-dom": "^6.11.0",
+        "zustand": "^4.3.8"
       },
       "devDependencies": {
         "@babel/core": "^7.21.0",
@@ -6185,6 +6186,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6463,6 +6472,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.8.tgz",
+      "integrity": "sha512-4h28KCkHg5ii/wcFFJ5Fp+k1J3gJoasaIbppdgZFO4BPJnsNxL0mQXBSFgOgAdCdBj35aDTPvdAJReTMntFPGg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.11.0"
+    "react-router-dom": "^6.11.0",
+    "zustand": "^4.3.8"
   }
 }

--- a/frontend/src/components/ChatGroup.js
+++ b/frontend/src/components/ChatGroup.js
@@ -8,15 +8,17 @@ import Avatar from '@mui/material/Avatar';
 import { useNavigate, useParams } from 'react-router-dom';
 import useAxiosProtected from '../utils/useAxiosProtected';
 import { renderDateTime } from '../utils/utils';
+import useMessageStore from '../utils/useMessageStore';
 
 function ChatGroup() {
   const { getUser } = useContext(AuthContext);
-  const [messages, setMessages] = useState([]);
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const messages = useMessageStore((state) => state.chatGroups[id]);
+  const setMessageList = useMessageStore((state) => state.setMessageList);
   const [chatMessage, setChatMessage] = useState('');
   const [members, setMembers] = useState([]);
   const axios = useAxiosProtected();
-  const navigate = useNavigate();
-  const { id } = useParams();
   const bottomScrollRef = useRef();
   const user = getUser();
 
@@ -34,9 +36,10 @@ function ChatGroup() {
   const scrollToBottom = () => bottomScrollRef.current.scrollIntoView({ behavior: 'auto' });
 
   useEffect(() => {
-    axios.get(`/api/chats/${id}/messages/`).then((response) => {
-      setMessages(response.data);
-    });
+    if (!messages) {
+      axios.get(`/api/chats/${id}/messages/`).then((response) => setMessageList(id, response.data));
+    }
+
     axios.get(`/api/chats/${id}/members/`).then((response) => {
       setMembers(response.data);
     });
@@ -61,7 +64,7 @@ function ChatGroup() {
             overflow: 'auto',
             overscrollBehavior: 'contain'
           }}>
-          {messages.map((msg) => {
+          {messages?.map((msg) => {
             const alignSelf = msg.user.id == user.user_id ? 'flex-end' : 'flex-start';
             return (
               <ListItem

--- a/frontend/src/components/ChatGroup.js
+++ b/frontend/src/components/ChatGroup.js
@@ -9,6 +9,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import useAxiosProtected from '../utils/useAxiosProtected';
 import { renderDateTime } from '../utils/utils';
 import useMessageStore from '../utils/useMessageStore';
+import useMembersStore from '../utils/useMembersStore';
 
 function ChatGroup() {
   const { getUser } = useContext(AuthContext);
@@ -17,7 +18,8 @@ function ChatGroup() {
   const messages = useMessageStore((state) => state.chatGroups[id]);
   const setMessageList = useMessageStore((state) => state.setMessageList);
   const [chatMessage, setChatMessage] = useState('');
-  const [members, setMembers] = useState([]);
+  const members = useMembersStore((state) => state.chatGroups[id]);
+  const setMembers = useMembersStore((state) => state.setMembers);
   const axios = useAxiosProtected();
   const bottomScrollRef = useRef();
   const user = getUser();
@@ -40,9 +42,11 @@ function ChatGroup() {
       axios.get(`/api/chats/${id}/messages/`).then((response) => setMessageList(id, response.data));
     }
 
-    axios.get(`/api/chats/${id}/members/`).then((response) => {
-      setMembers(response.data);
-    });
+    if (!members) {
+      axios.get(`/api/chats/${id}/members/`).then((response) => {
+        setMembers(id, response.data);
+      });
+    }
   }, [id]);
 
   useEffect(() => {
@@ -117,7 +121,7 @@ function ChatGroup() {
             overflow: 'auto',
             overscrollBehavior: 'contain'
           }}>
-          {members.map((member) => {
+          {members?.map((member) => {
             return (
               <ListItem key={member.user.id} disableGutters>
                 <ListItemAvatar>

--- a/frontend/src/components/Friends.js
+++ b/frontend/src/components/Friends.js
@@ -9,17 +9,21 @@ import Avatar from '@mui/material/Avatar';
 import ListItemText from '@mui/material/ListItemText';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { IconButton } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import useAxiosProtected from '../utils/useAxiosProtected';
+import useFriendsListStore from '../utils/useFriendsListStore';
 
 function Friends() {
-  const [friendsList, setFriendsList] = useState([]);
+  const friendsList = useFriendsListStore((state) => state.friendsList);
+  const setFriendsList = useFriendsListStore((state) => state.setFriendsList);
   const axios = useAxiosProtected();
 
   useEffect(() => {
-    axios.get('/api/users/me/friends/').then((response) => {
-      setFriendsList(response.data);
-    });
+    if (!friendsList) {
+      axios.get('/api/users/me/friends/').then((response) => {
+        setFriendsList(response.data);
+      });
+    }
   }, []);
 
   return (
@@ -34,7 +38,7 @@ function Friends() {
       <Typography style={{ marginBottom: '8px' }}>Friends</Typography>
       <Divider />
       <List style={{ maxHeight: '78vh', overflowY: 'auto', overscrollBehavior: 'contain' }}>
-        {friendsList.map((friend) => {
+        {friendsList?.map((friend) => {
           return (
             <ListItem key={friend.id} disableGutters divider>
               <ListItemAvatar>

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -68,7 +68,7 @@ function Sidebar() {
           </ListItem>
         </List>
         <Divider />
-        <List style={{ maxHeight: '68vh', overflowY: 'auto', overscrollBehavior: 'contain' }}>
+        <List style={{ maxHeight: '80vh', overflowY: 'auto', overscrollBehavior: 'contain' }}>
           <ListItem key={-1} disablePadding>
             <ListItemText primaryTypographyProps={{ fontFamily: 'NotoSans' }}>
               CHAT GROUPS

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -19,10 +19,13 @@ import BaseFormDialog from './BaseFormDialog';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { Button, DialogActions, DialogContent, DialogContentText, TextField } from '@mui/material';
 import AuthContext from '../utils/AuthContext';
+import useChatGroupStore from '../utils/useChatGroupStore';
 
 function Sidebar() {
   const axios = useAxiosProtected();
-  const [chatGroups, setChatGroups] = useState([]);
+  const chatGroups = useChatGroupStore((state) => state.chatGroups);
+  const setChatGroups = useChatGroupStore((state) => state.setChatGroups);
+
   const [openDialog, setOpenDialog] = useState(false);
   const navigate = useNavigate();
   const friendsText = 'Friends';
@@ -108,13 +111,18 @@ function NewChatGroupFormDialog({ open, setOpen }) {
   const axios = useAxiosProtected();
   const { getUser } = useContext(AuthContext);
   const navigate = useNavigate();
+  const addChatGroup = useChatGroupStore((state) => state.addChatGroup);
   const handleClose = useCallback((e) => {
     e.preventDefault();
     if (e.target.name) {
+      const name = e.target.name.value;
       axios
-        .post('/api/chats/', { owner: getUser()?.user_id, name: e.target.name.value })
+        .post('/api/chats/', { owner: getUser()?.user_id, name: name })
         .then((response) => {
           const id = response?.data['id'];
+          // FIXME: The backend should return the same object keys that are seen when
+          // fetching the chat group list!
+          addChatGroup({ id: id, name: name });
           navigate(`/dashboard/chats/${id}`);
         })
         .catch(() => console.log('Unable to create a new chat group!'));

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -5,12 +5,12 @@ import useSubscriber from '../utils/useSubscriber';
 import useMessageStore from '../utils/useMessageStore';
 
 function Dashboard() {
-  const addMessageFromEvent = useMessageStore((state) => state.addMessageFromEvent);
+  const addMessage = useMessageStore((state) => state.addMessage);
 
   useSubscriber((event) => {
     switch (event.event_type) {
       case 'group:message':
-        addMessageFromEvent(event);
+        addMessage(event.message);
     }
   });
 

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,18 +1,18 @@
 import Sidebar from '../components/Sidebar';
 import ActivityView from '../components/ActivityView';
 import Box from '@mui/material/Box';
-import { useContext } from 'react';
 import useSubscriber from '../utils/useSubscriber';
-import AuthContext from '../utils/AuthContext';
-import { useNavigate } from 'react-router-dom';
+import useMessageStore from '../utils/useMessageStore';
 
 function Dashboard() {
-  const { getAuthTokens } = useContext(AuthContext);
-  const tokens = getAuthTokens();
-  const navigate = useNavigate();
-  if (!tokens) navigate('/');
+  const addMessageFromEvent = useMessageStore((state) => state.addMessageFromEvent);
 
-  useSubscriber((message) => console.log(message));
+  useSubscriber((event) => {
+    switch (event.event_type) {
+      case 'group:message':
+        addMessageFromEvent(event);
+    }
+  });
 
   return (
     <Box

--- a/frontend/src/utils/useChatGroupStore.js
+++ b/frontend/src/utils/useChatGroupStore.js
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+const useChatGroupStore = create((set, get) => ({
+  chatGroups: [],
+  setChatGroups: (chatGroups) => {
+    set(() => ({
+      chatGroups: [...chatGroups]
+    }));
+  },
+  addChatGroup: (chatGroup) => {
+    set((state) => ({
+      chatGroups: [...state.chatGroups, chatGroup]
+    }));
+  }
+}));
+
+export default useChatGroupStore;

--- a/frontend/src/utils/useFriendsListStore.js
+++ b/frontend/src/utils/useFriendsListStore.js
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+const useFriendsListStore = create((set, get) => ({
+  friendsList: null,
+  setFriendsList: (list) => {
+    set(() => ({
+      friendsList: [...list]
+    }));
+  },
+  addFriend: (friend) => {
+    set((state) => ({
+      friendsList: [...state.friendsList, friend]
+    }));
+  }
+}));
+
+export default useFriendsListStore;

--- a/frontend/src/utils/useMembersStore.js
+++ b/frontend/src/utils/useMembersStore.js
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+const useMembersStore = create((set, get) => ({
+  chatGroups: {},
+  setMembers: (chatId, members) => {
+    set((state) => ({
+      chatGroups: {
+        ...state.chatGroups,
+        [chatId]: members
+      }
+    }));
+  },
+  addMember: (member) => {
+    const chatId = member.chat_group;
+    if (!get().chatGroups[chatId]) return;
+
+    set((state) => ({
+      chatGroups: {
+        ...state.chatGroups,
+        [chatId]: [...state.chatGroups[chatId], member]
+      }
+    }));
+  }
+}));
+
+export default useMembersStore;

--- a/frontend/src/utils/useMessageStore.js
+++ b/frontend/src/utils/useMessageStore.js
@@ -10,15 +10,14 @@ const useMessageStore = create((set, get) => ({
       }
     }));
   },
-  addMessageFromEvent: (event) => {
-    const message = event.message;
+  addMessage: (message) => {
     const chatId = message.chat_group;
     if (!get().chatGroups[chatId]) return;
 
     set((state) => ({
       chatGroups: {
         ...state.chatGroups,
-        [chatId]: [...state.chatGroups[chatId], event.message]
+        [chatId]: [...state.chatGroups[chatId], message]
       }
     }));
   }

--- a/frontend/src/utils/useMessageStore.js
+++ b/frontend/src/utils/useMessageStore.js
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+const useMessageStore = create((set, get) => ({
+  chatGroups: {},
+  setMessageList: (chatId, messages) => {
+    set((state) => ({
+      chatGroups: {
+        ...state.chatGroups,
+        [chatId]: messages
+      }
+    }));
+  },
+  addMessageFromEvent: (event) => {
+    const message = event.message;
+    const chatId = message.chat_group;
+    if (!get().chatGroups[chatId]) return;
+
+    set((state) => ({
+      chatGroups: {
+        ...state.chatGroups,
+        [chatId]: [...state.chatGroups[chatId], event.message]
+      }
+    }));
+  }
+}));
+
+export default useMessageStore;

--- a/frontend/src/utils/useSubscriber.js
+++ b/frontend/src/utils/useSubscriber.js
@@ -8,7 +8,7 @@ import jwtDecode from 'jwt-decode';
 // while other events are being processed. We should question if such a buffer is
 // scalable for a chat app.
 
-function useSubscriber(onMessage) {
+function useSubscriber(onEvent) {
   const { getAuthTokens, storeAuthTokens, logoutUser } = useContext(AuthContext);
   const tokens = getAuthTokens();
   const webSocket = useRef(null);
@@ -16,7 +16,7 @@ function useSubscriber(onMessage) {
   const navigate = useNavigate();
   const handleIncomingMessage = useCallback((message) => {
     const data = JSON.parse(message.data);
-    onMessage(data);
+    onEvent(data);
   });
 
   const setupConnection = useCallback((url) => {


### PR DESCRIPTION
Though much more work needs to be done with the dashboard (including adding more APIs to the frontend for it to consume), this resolves #5.

This is just a basic implementation. When pagination is implemented for list-based views, I would like to make memory optimizations (such as taking a LRU approach to how data is stored) and I expect the underlying data structures within the store to change.